### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -1,0 +1,27 @@
+---
+name: Meeting
+about: Create this for the next meeting
+title: 'Meeting: '
+labels: Meeting
+assignees: ''
+
+---
+
+We've got a new meeting coming up 🎉😎
+
+## When
+
+## Where
+
+## Talks
+
+## Other blurb
+
+## Standard info
+* Everyone who comes should follow the [code of conduct](https://github.com/vancouver/vanpy/blob/master/code_of_conduct.md), which we will enforce. Be nice to each other and make a space we can all visit.
+* We'll try to make every meeting a hybrid one, so people can can join remotely. We do understand that not everyone is comfortable turning up to a room full of people.
+* If there is a room limit, we'll come up with a system to figure that out.
+* Recording the meeting isn't something we plan on doing just yet.
+* We encourage speakers to share their slides and demos later on if possible, but its up to the speakers.
+
+That's it, we hope you can join us and come hang out with fellow Python people.

--- a/.github/ISSUE_TEMPLATE/space-offer.md
+++ b/.github/ISSUE_TEMPLATE/space-offer.md
@@ -1,0 +1,38 @@
+---
+name: Space offer
+about: We'd like to offer space for a meeting
+title: 'Offer of space: '
+labels: Space offer
+assignees: ''
+
+---
+
+The vanpy user group needs space to meet up and chat, so we are always on the lookout for a space. You could offer space for one event, or ongoing.
+
+If you are filling out this form with an offer to host an event, a big thank you from the organizers. We need your help to make this happen. 🙇
+
+## What we need to know
+Please replace the bits below with your information 👇
+
+* **Who:** Company name etc.
+* **Contact info:** We are going to assume its you, but it might be someone else. Don't put anyones personal information here though, this is public 😀
+* **Where:** Where the space is so we can get there.
+* **When:** Is this limited to a particular time period, or just open for anytime?
+
+**What you as the organiser needs to know**
+We are just a bunch of amazing people who want to hang out and talk about Python. As such there's not much we need, but do need you to check off the following are all cool: 😎
+
+* [ ] A space that is welcome to all people of gender, nationality etc please see [our code of conduct](https://github.com/vancouver/vanpy/blob/master/code_of_conduct.md).
+* [ ] Space for people to sit, usually 12 - 50 (depending how many people come).
+* [ ] Easyish for people to get to (Vancouver and downtown, near public transit for example).
+* [ ] Good wifi for presentations and demos and so people can join remotely.
+* [ ] A big screen we can connect a laptop too for presentations and demos.
+* [ ] Washroom access.
+
+Things that we can't do: 😭
+* Sign non-disclosures or other agreements to hang out there.
+* Any sort of insurance requirements.
+* Pay for things.
+
+## Additional context
+Anything else we should know.

--- a/.github/ISSUE_TEMPLATE/talk-proposal.md
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.md
@@ -1,0 +1,30 @@
+---
+name: Talk proposal
+about: Use this to propose a talk
+title: 'Talk proposal: '
+labels: Talk Proposal
+assignees: ''
+
+---
+
+If you are using this form, a big thank you from the organisers 🙇‍♀ talks really help pull people in.
+
+Anyone is welcome to talk on any topic. In the past we've talks on a super wide range of topics and we'd welcome anyone, from those new to giving talks to those experience conference speakers. Talks can be from 5-45 mins long. I mean you could do longer if you want...
+
+## About the talk
+Please replace the following bits below 👇
+
+* **Title**: What you are going to talk about.
+* **Description**: The longer version of the above.
+* **Duration (approx.)**: We aren't going to hold you to his, don't worry. But if its short, it means we can get in a few talks in one meeting.
+
+## What you as a talk proposer need to know
+
+If you could just check these off so we know you've read them.
+* [ ] Please ensure you've [read the code of conduct](https://github.com/vancouver/vanpy/blob/master/code_of_conduct.md)
+* [ ] Don't say things that are confidential and will get your, company, or anyone in the audience in any legal trouble 🤑
+* [ ] The person hosting the space will provide Wifi and an a screen, we'll have people dialing in remotely. If there's anything else you need, you'll let us know right? 😀
+* [ ] After the talk, positing slides and code and somewhere (even this repo) would be appreciated, but its not required.
+
+## Additional context
+Anything else you'd want to add.


### PR DESCRIPTION
The start of the move away from meetup and a simple way to manage: talk requests, offers of space and then meetings. Basically I feel like I can do all this in GitHub without much effort.