### PR TITLE
Post new meeting issues to Mastodon via Github Actions

### DIFF
--- a/.github/workflows/announce-meeting.yaml
+++ b/.github/workflows/announce-meeting.yaml
@@ -1,0 +1,21 @@
+name: Announce new meeting on Mastodon
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'Meeting'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - name: Send toot to Mastodon
+      id: mastodon
+      uses: cbrgm/mastodon-github-action@v1
+      with:
+        message: "New Vancouver Python User Group meeting announced! ${{ github.event.issue.title }}"
+        visibility: "public"
+      env:
+        MASTODON_URL: ${{ secrets.MASTODON_URL }}
+        MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}


### PR DESCRIPTION
Hi everyone! I scribbled this quick Github Actions thing using [this action](https://github.com/cbrgm/mastodon-github-action) as a base so that any new issue that is labelled "Meeting" will be posted to Mastodon, following a comment in #4 

We'd need to set up the instance URL and the access token onto the repo's secret variables and then test it out

Happy to make any changes or adjustments if needed!